### PR TITLE
Add deletion option for saved SEO ranking records

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -9,6 +9,7 @@ import {
   getFirestore,
   doc,
   setDoc,
+  deleteDoc,
   collection,
   onSnapshot,
   serverTimestamp,
@@ -186,6 +187,14 @@ async function logSeoData({ date, note, rankings }) {
   return true;
 }
 
+/** Firestore: 삭제 */
+async function deleteSeoData(date) {
+  if (!db) throw new Error('Firebase가 초기화되지 않았습니다.');
+  const ref = doc(db, 'seoRanks', date);
+  await deleteDoc(ref);
+  return true;
+}
+
 /** Firestore: 실시간 구독 */
 function useSeoDataRealtime() {
   const [data, setData] = useState({});
@@ -217,6 +226,16 @@ export default function Home() {
   const [msg, setMsg] = useState(null);
 
   const allSeoData = useSeoDataRealtime();
+
+  const handleDelete = async (targetDate) => {
+    if (!window.confirm(`${targetDate} 데이터를 삭제하시겠습니까?`)) return;
+    try {
+      await deleteSeoData(targetDate);
+      setMsg('삭제되었습니다.');
+    } catch (e) {
+      setMsg(`삭제 중 오류: ${e.message}`);
+    }
+  };
 
   // 초기 리스트 표시용
   useEffect(() => {
@@ -397,7 +416,15 @@ export default function Home() {
               const sobang = details?.rankings?.sobang ?? {};
               return (
                 <div key={d} className={styles.savedCard}>
-                  <p className={styles.savedDate}>{d}</p>
+                  <div className={styles.savedHeader}>
+                    <p className={styles.savedDate}>{d}</p>
+                    <button
+                      className={styles.deleteButton}
+                      onClick={() => handleDelete(d)}
+                    >
+                      삭제
+                    </button>
+                  </div>
                   <div className={styles.tablesGrid}>
                     {/* 공무원 테이블 */}
                     <div>

--- a/src/app/page.module.scss
+++ b/src/app/page.module.scss
@@ -271,6 +271,32 @@
         display: grid;
         gap: 14px;
 
+        .savedHeader {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+
+          .deleteButton {
+            appearance: none;
+            border: none;
+            background: transparent;
+            color: var(--warning);
+            cursor: pointer;
+            padding: 4px 8px;
+            border-radius: var(--radius-sm);
+            font-size: 13px;
+            transition: opacity 0.2s ease;
+
+            &:hover {
+              opacity: 0.8;
+            }
+
+            &:focus-visible {
+              @include m.focus-ring;
+            }
+          }
+        }
+
         .savedDate {
           margin: 0;
           font-weight: 800;


### PR DESCRIPTION
## Summary
- allow removing stored SEO rank data from Firestore
- style and expose delete buttons for each stored SEO entry

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a679f1f924832490734c075ced11ca