### PR TITLE
feat: apply Noto Sans KR font and icon theme toggle

### DIFF
--- a/src/app/globals.scss
+++ b/src/app/globals.scss
@@ -54,8 +54,7 @@
 html,
 body {
   height: 100%;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
-    Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  font-family: 'Noto Sans KR', sans-serif;
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
   background: var(--bg);
@@ -120,10 +119,18 @@ header img {
 header button {
   background: none;
   border: 1px solid var(--border);
-  padding: 0.25rem 0.75rem;
+  padding: 0.25rem;
   border-radius: var(--radius-sm);
   color: var(--text);
   cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+header button svg {
+  width: 20px;
+  height: 20px;
 }
 
 footer {

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,6 +1,13 @@
 import './globals.scss';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
+import { Noto_Sans_KR } from 'next/font/google';
+
+const notoSansKr = Noto_Sans_KR({
+  subsets: ['latin'],
+  weight: ['400', '700'],
+  display: 'swap',
+});
 
 export const metadata = {
   title: 'Nextstudy SEO Master',
@@ -13,7 +20,7 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang='ko'>
-      <body>
+      <body className={notoSansKr.className}>
         <Header />
         {children}
         <Footer />

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -8,9 +8,7 @@ export default function Header() {
 
   useEffect(() => {
     const stored = localStorage.getItem('theme');
-    const prefersDark = window.matchMedia(
-      '(prefers-color-scheme: dark)'
-    ).matches;
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
     const initial = stored || (prefersDark ? 'dark' : 'light');
     setTheme(initial);
     document.documentElement.setAttribute('data-theme', initial);
@@ -31,10 +29,36 @@ export default function Header() {
         ) : (
           <img src='/images/logo.png' alt='Nextstudy logo' />
         )}
-        <button onClick={toggleTheme}>
-          {theme === 'light' ? 'Dark Mode' : 'Light Mode'}
+        <button onClick={toggleTheme} aria-label='Toggle theme'>
+          {theme === 'light' ? (
+            <svg
+              xmlns='http://www.w3.org/2000/svg'
+              viewBox='0 0 24 24'
+              fill='none'
+              stroke='currentColor'
+              strokeWidth='2'
+              strokeLinecap='round'
+              strokeLinejoin='round'
+            >
+              <path d='M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z' />
+            </svg>
+          ) : (
+            <svg
+              xmlns='http://www.w3.org/2000/svg'
+              viewBox='0 0 24 24'
+              fill='none'
+              stroke='currentColor'
+              strokeWidth='2'
+              strokeLinecap='round'
+              strokeLinejoin='round'
+            >
+              <circle cx='12' cy='12' r='5' />
+              <path d='M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42' />
+            </svg>
+          )}
         </button>
       </div>
     </header>
   );
 }
+


### PR DESCRIPTION
## Summary
- load Noto Sans KR font and apply globally
- replace dark/light mode toggle text with sun and moon icons
- adjust header button styles for icon-based toggle

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a6a165ecc88324ba0952b2054d784f