### PR TITLE
feat: track multiple megagong ranks in top results

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -118,14 +118,10 @@ function rankText(value) {
   if (rank === 'N/A' || rank === null || rank === undefined)
     return { primary: '순위 없음', detail: '' };
   const count =
-    typeof value === 'object' && value.top10Count > 1
-      ? value.top10Count
-      : 0;
+    typeof value === 'object' && value.top10Count > 1 ? value.top10Count : 0;
   return {
     primary: `${rank}위`,
-    detail: count
-      ? `최고 순위 ${rank}위 / 10위내 포함 ${count}건`
-      : '',
+    detail: count ? `최고 순위 ${rank}위 / 10위내 포함 ${count}건` : '',
   };
 }
 
@@ -285,15 +281,13 @@ export default function Home() {
   const [msg, setMsg] = useState(null);
 
   const allSeoData = useSeoDataRealtime();
-  const seoEntries = useMemo(
-    () => Object.entries(allSeoData),
-    [allSeoData]
-  );
+  const seoEntries = useMemo(() => Object.entries(allSeoData), [allSeoData]);
   const [chartLimit, setChartLimit] = useState(7);
   const [openCards, setOpenCards] = useState({});
 
   const { gongChartOptions, sobangChartOptions } = useMemo(() => {
-    if (seoEntries.length === 0) return { gongChartOptions: null, sobangChartOptions: null };
+    if (seoEntries.length === 0)
+      return { gongChartOptions: null, sobangChartOptions: null };
     const sorted = [...seoEntries].sort((a, b) => a[0].localeCompare(b[0]));
     const limited = sorted.slice(-chartLimit);
     const dates = limited.map(([d]) => d);
@@ -406,6 +400,13 @@ export default function Home() {
     sobangKeywords.forEach((k) => (initSc[k] = 0));
     setSobangCount(initSc);
   }, []);
+
+  useEffect(() => {
+    if (seoEntries.length > 0) {
+      const latestDate = seoEntries[0][0];
+      setOpenCards({ [latestDate]: true });
+    }
+  }, [seoEntries]);
 
   const handleFetchGong = async () => {
     setIsGongDone(false);
@@ -534,7 +535,9 @@ export default function Home() {
                   <span className={styles.keywordRank}>
                     <em>{info.primary}</em>
                     {info.detail && (
-                      <span className={styles.keywordDetail}>{info.detail}</span>
+                      <span className={styles.keywordDetail}>
+                        {info.detail}
+                      </span>
                     )}
                     {gongSource[kw] && gongState[kw] !== 'loading' && (
                       <a
@@ -577,7 +580,9 @@ export default function Home() {
                   <span className={styles.keywordRank}>
                     <em>{info.primary}</em>
                     {info.detail && (
-                      <span className={styles.keywordDetail}>{info.detail}</span>
+                      <span className={styles.keywordDetail}>
+                        {info.detail}
+                      </span>
                     )}
                     {sobangSource[kw] && sobangState[kw] !== 'loading' && (
                       <a
@@ -717,125 +722,129 @@ export default function Home() {
                           <div>
                             <h4 className={styles.tableTitle}>공무원</h4>
                             <table className={styles.dataTable}>
-                          <colgroup>
-                            <col width='45%' />
-                            <col width='*' />
-                          </colgroup>
-                          <thead>
-                            <tr>
-                              <th>핵심키워드</th>
-                              <th>순위</th>
-                            </tr>
-                          </thead>
-                          <tbody>
-                            {Object.entries(gong).map(([kw, r]) => {
-                              const value = getRankValue(r);
-                              const src =
-                                typeof r === 'object' && r.source
-                                  ? r.source
-                                  : '';
-                              const prevValue = prevGong[kw];
-                              const info =
-                                value === 'loading'
-                                  ? { primary: '로딩', detail: '' }
-                                  : value === null
-                                  ? { primary: '집계전', detail: '' }
-                                  : rankText(r);
-                              return (
-                                <tr key={kw}>
-                                  <td>{kw}</td>
-                                  <td>
-                                    {prevDetails &&
-                                      renderChange(value, prevValue)}
-                                    {info.primary}
-                                    {info.detail && (
-                                      <span className={styles.tableRankDetail}>
-                                        {info.detail}
-                                      </span>
-                                    )}
-                                    {src && (
-                                      <a
-                                        className={styles.tableSource}
-                                        href={src}
-                                        target='_blank'
-                                        rel='noopener noreferrer'
-                                      >
-                                        {src.replace(/^https?:\/\//, '')}
-                                      </a>
-                                    )}
-                                  </td>
+                              <colgroup>
+                                <col width='45%' />
+                                <col width='*' />
+                              </colgroup>
+                              <thead>
+                                <tr>
+                                  <th>핵심키워드</th>
+                                  <th>순위</th>
                                 </tr>
-                              );
-                            })}
-                          </tbody>
-                        </table>
-                      </div>
+                              </thead>
+                              <tbody>
+                                {Object.entries(gong).map(([kw, r]) => {
+                                  const value = getRankValue(r);
+                                  const src =
+                                    typeof r === 'object' && r.source
+                                      ? r.source
+                                      : '';
+                                  const prevValue = prevGong[kw];
+                                  const info =
+                                    value === 'loading'
+                                      ? { primary: '로딩', detail: '' }
+                                      : value === null
+                                      ? { primary: '집계전', detail: '' }
+                                      : rankText(r);
+                                  return (
+                                    <tr key={kw}>
+                                      <td>{kw}</td>
+                                      <td>
+                                        {prevDetails &&
+                                          renderChange(value, prevValue)}
+                                        {info.primary}
+                                        {info.detail && (
+                                          <span
+                                            className={styles.tableRankDetail}
+                                          >
+                                            {info.detail}
+                                          </span>
+                                        )}
+                                        {src && (
+                                          <a
+                                            className={styles.tableSource}
+                                            href={src}
+                                            target='_blank'
+                                            rel='noopener noreferrer'
+                                          >
+                                            {src.replace(/^https?:\/\//, '')}
+                                          </a>
+                                        )}
+                                      </td>
+                                    </tr>
+                                  );
+                                })}
+                              </tbody>
+                            </table>
+                          </div>
 
-                        {/* 소방 테이블 */}
+                          {/* 소방 테이블 */}
+                          <div>
+                            <h4 className={styles.tableTitle}>소방</h4>
+                            <table className={styles.dataTable}>
+                              <colgroup>
+                                <col width='45%' />
+                                <col width='*' />
+                              </colgroup>
+                              <thead>
+                                <tr>
+                                  <th>핵심키워드</th>
+                                  <th>순위</th>
+                                </tr>
+                              </thead>
+                              <tbody>
+                                {Object.entries(sobang).map(([kw, r]) => {
+                                  const value = getRankValue(r);
+                                  const src =
+                                    typeof r === 'object' && r.source
+                                      ? r.source
+                                      : '';
+                                  const prevValue = prevSobang[kw];
+                                  const info =
+                                    value === 'loading'
+                                      ? { primary: '로딩', detail: '' }
+                                      : value === null
+                                      ? { primary: '집계전', detail: '' }
+                                      : rankText(r);
+                                  return (
+                                    <tr key={kw}>
+                                      <td>{kw}</td>
+                                      <td>
+                                        {prevDetails &&
+                                          renderChange(value, prevValue)}
+                                        {info.primary}
+                                        {info.detail && (
+                                          <span
+                                            className={styles.tableRankDetail}
+                                          >
+                                            {info.detail}
+                                          </span>
+                                        )}
+                                        {src && (
+                                          <a
+                                            className={styles.tableSource}
+                                            href={src}
+                                            target='_blank'
+                                            rel='noopener noreferrer'
+                                          >
+                                            {src.replace(/^https?:\/\//, '')}
+                                          </a>
+                                        )}
+                                      </td>
+                                    </tr>
+                                  );
+                                })}
+                              </tbody>
+                            </table>
+                          </div>
+                        </div>
+
                         <div>
-                          <h4 className={styles.tableTitle}>소방</h4>
-                          <table className={styles.dataTable}>
-                            <colgroup>
-                              <col width='45%' />
-                              <col width='*' />
-                            </colgroup>
-                            <thead>
-                              <tr>
-                                <th>핵심키워드</th>
-                                <th>순위</th>
-                              </tr>
-                            </thead>
-                            <tbody>
-                              {Object.entries(sobang).map(([kw, r]) => {
-                                const value = getRankValue(r);
-                                const src =
-                                  typeof r === 'object' && r.source
-                                    ? r.source
-                                    : '';
-                                const prevValue = prevSobang[kw];
-                                const info =
-                                  value === 'loading'
-                                    ? { primary: '로딩', detail: '' }
-                                    : value === null
-                                    ? { primary: '집계전', detail: '' }
-                                    : rankText(r);
-                                return (
-                                  <tr key={kw}>
-                                    <td>{kw}</td>
-                                    <td>
-                                      {prevDetails &&
-                                        renderChange(value, prevValue)}
-                                      {info.primary}
-                                      {info.detail && (
-                                        <span className={styles.tableRankDetail}>
-                                          {info.detail}
-                                        </span>
-                                      )}
-                                      {src && (
-                                        <a
-                                          className={styles.tableSource}
-                                          href={src}
-                                          target='_blank'
-                                          rel='noopener noreferrer'
-                                        >
-                                          {src.replace(/^https?:\/\//, '')}
-                                        </a>
-                                      )}
-                                    </td>
-                                  </tr>
-                                );
-                              })}
-                            </tbody>
-                          </table>
+                          <strong>비고</strong>
+                          <div className={styles.note}>
+                            {renderNote(details?.note)}
+                          </div>
                         </div>
-                      </div>
-
-                      <div>
-                        <strong>비고</strong>
-                        <div className={styles.note}>
-                          {renderNote(details?.note)}
-                        </div>
-                      </div>
                       </>
                     )}
                   </div>

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -114,14 +114,19 @@ function renderNote(note) {
 /** rank 표시 텍스트 */
 function rankText(value) {
   const rank = getRankValue(value);
-  if (rank === '오류 발생') return '오류 발생';
+  if (rank === '오류 발생') return { primary: '오류 발생', detail: '' };
   if (rank === 'N/A' || rank === null || rank === undefined)
-    return '순위 없음';
+    return { primary: '순위 없음', detail: '' };
   const count =
     typeof value === 'object' && value.top10Count > 1
-      ? ` / 10위내 포함 ${value.top10Count}건`
-      : '';
-  return count ? `최고 순위 ${rank}위${count}` : `${rank}위`;
+      ? value.top10Count
+      : 0;
+  return {
+    primary: `${rank}위`,
+    detail: count
+      ? `최고 순위 ${rank}위 / 10위내 포함 ${count}건`
+      : '',
+  };
 }
 
 // ====== API ======
@@ -512,34 +517,39 @@ export default function Home() {
             <button onClick={handleFetchGong}>순위 가져오기</button>
           </div>
           <ul className={styles.keywordList}>
-            {gongKeywords.map((kw, idx) => (
-              <li key={kw} className={styles.keywordItem}>
-                <span>{idx + 1}</span>
-                <span>{kw}</span>
-                <span className={styles.keywordRank}>
-                  <em>
-                    {gongState[kw] === 'loading'
-                      ? '로드중'
-                      : gongState[kw] === null
-                      ? '집계전'
-                      : rankText({
-                          rank: gongState[kw],
-                          top10Count: gongCount[kw],
-                        })}
-                  </em>
-                  {gongSource[kw] && gongState[kw] !== 'loading' && (
-                    <a
-                      className={styles.keywordSource}
-                      href={gongSource[kw]}
-                      target='_blank'
-                      rel='noopener noreferrer'
-                    >
-                      {gongSource[kw].replace(/^https?:\/\//, '')}
-                    </a>
-                  )}
-                </span>
-              </li>
-            ))}
+            {gongKeywords.map((kw, idx) => {
+              const info =
+                gongState[kw] === 'loading'
+                  ? { primary: '로드중', detail: '' }
+                  : gongState[kw] === null
+                  ? { primary: '집계전', detail: '' }
+                  : rankText({
+                      rank: gongState[kw],
+                      top10Count: gongCount[kw],
+                    });
+              return (
+                <li key={kw} className={styles.keywordItem}>
+                  <span>{idx + 1}</span>
+                  <span>{kw}</span>
+                  <span className={styles.keywordRank}>
+                    <em>{info.primary}</em>
+                    {info.detail && (
+                      <span className={styles.keywordDetail}>{info.detail}</span>
+                    )}
+                    {gongSource[kw] && gongState[kw] !== 'loading' && (
+                      <a
+                        className={styles.keywordSource}
+                        href={gongSource[kw]}
+                        target='_blank'
+                        rel='noopener noreferrer'
+                      >
+                        {gongSource[kw].replace(/^https?:\/\//, '')}
+                      </a>
+                    )}
+                  </span>
+                </li>
+              );
+            })}
           </ul>
         </div>
 
@@ -550,34 +560,39 @@ export default function Home() {
             <button onClick={handleFetchSobang}>순위 가져오기</button>
           </div>
           <ul className={styles.keywordList}>
-            {sobangKeywords.map((kw, idx) => (
-              <li key={kw} className={styles.keywordItem}>
-                <span>{idx + 1}</span>
-                <span>{kw}</span>
-                <span className={styles.keywordRank}>
-                  <em>
-                    {sobangState[kw] === 'loading'
-                      ? '로드중'
-                      : sobangState[kw] === null
-                      ? '집계전'
-                      : rankText({
-                          rank: sobangState[kw],
-                          top10Count: sobangCount[kw],
-                        })}
-                  </em>
-                  {sobangSource[kw] && sobangState[kw] !== 'loading' && (
-                    <a
-                      className={styles.keywordSource}
-                      href={sobangSource[kw]}
-                      target='_blank'
-                      rel='noopener noreferrer'
-                    >
-                      {sobangSource[kw].replace(/^https?:\/\//, '')}
-                    </a>
-                  )}
-                </span>
-              </li>
-            ))}
+            {sobangKeywords.map((kw, idx) => {
+              const info =
+                sobangState[kw] === 'loading'
+                  ? { primary: '로드중', detail: '' }
+                  : sobangState[kw] === null
+                  ? { primary: '집계전', detail: '' }
+                  : rankText({
+                      rank: sobangState[kw],
+                      top10Count: sobangCount[kw],
+                    });
+              return (
+                <li key={kw} className={styles.keywordItem}>
+                  <span>{idx + 1}</span>
+                  <span>{kw}</span>
+                  <span className={styles.keywordRank}>
+                    <em>{info.primary}</em>
+                    {info.detail && (
+                      <span className={styles.keywordDetail}>{info.detail}</span>
+                    )}
+                    {sobangSource[kw] && sobangState[kw] !== 'loading' && (
+                      <a
+                        className={styles.keywordSource}
+                        href={sobangSource[kw]}
+                        target='_blank'
+                        rel='noopener noreferrer'
+                      >
+                        {sobangSource[kw].replace(/^https?:\/\//, '')}
+                      </a>
+                    )}
+                  </span>
+                </li>
+              );
+            })}
           </ul>
         </div>
       </div>
@@ -720,17 +735,24 @@ export default function Home() {
                                   ? r.source
                                   : '';
                               const prevValue = prevGong[kw];
+                              const info =
+                                value === 'loading'
+                                  ? { primary: '로딩', detail: '' }
+                                  : value === null
+                                  ? { primary: '집계전', detail: '' }
+                                  : rankText(r);
                               return (
                                 <tr key={kw}>
                                   <td>{kw}</td>
                                   <td>
                                     {prevDetails &&
                                       renderChange(value, prevValue)}
-                                    {value === 'loading'
-                                      ? '로딩'
-                                      : value === null
-                                      ? '집계전'
-                                      : rankText(r)}
+                                    {info.primary}
+                                    {info.detail && (
+                                      <span className={styles.tableRankDetail}>
+                                        {info.detail}
+                                      </span>
+                                    )}
                                     {src && (
                                       <a
                                         className={styles.tableSource}
@@ -771,17 +793,24 @@ export default function Home() {
                                     ? r.source
                                     : '';
                                 const prevValue = prevSobang[kw];
+                                const info =
+                                  value === 'loading'
+                                    ? { primary: '로딩', detail: '' }
+                                    : value === null
+                                    ? { primary: '집계전', detail: '' }
+                                    : rankText(r);
                                 return (
                                   <tr key={kw}>
                                     <td>{kw}</td>
                                     <td>
                                       {prevDetails &&
                                         renderChange(value, prevValue)}
-                                      {value === 'loading'
-                                        ? '로딩'
-                                        : value === null
-                                        ? '집계전'
-                                        : rankText(r)}
+                                      {info.primary}
+                                      {info.detail && (
+                                        <span className={styles.tableRankDetail}>
+                                          {info.detail}
+                                        </span>
+                                      )}
                                       {src && (
                                         <a
                                           className={styles.tableSource}

--- a/src/app/page.module.scss
+++ b/src/app/page.module.scss
@@ -141,6 +141,13 @@
               }
             }
 
+            .keywordDetail {
+              margin-top: 2px;
+              font-size: 12px;
+              font-weight: 400;
+              color: var(--text-sub);
+            }
+
             .keywordSource {
               margin-top: 2px;
               font-size: 12px;
@@ -474,6 +481,13 @@
               font-size: 11px;
               color: var(--text-sub);
               text-decoration: none;
+            }
+
+            .tableRankDetail {
+              display: block;
+              margin-top: 2px;
+              font-size: 11px;
+              color: var(--text-sub);
             }
 
             .rankChange {

--- a/src/app/page.module.scss
+++ b/src/app/page.module.scss
@@ -487,7 +487,8 @@
               display: block;
               margin-top: 2px;
               font-size: 11px;
-              color: var(--text-sub);
+              color: var(--primary);
+              font-weight: 700;
             }
 
             .rankChange {

--- a/src/pages/api/rank/[keyword].js
+++ b/src/pages/api/rank/[keyword].js
@@ -36,6 +36,7 @@ export default async function handler(req, res) {
     let searchResults = [];
     let foundMegagongRank = null;
     let foundMegagongUrl = null;
+    let megagongTop10Count = 0;
 
     while (currentPage <= 5) {
       const searchURL = `https://www.google.com/search?q=${encodeURIComponent(
@@ -66,6 +67,9 @@ export default async function handler(req, res) {
       const megagongResult = searchResults.find((result) =>
         result.url.includes('megagong.net')
       );
+      megagongTop10Count = searchResults.filter(
+        (r) => r.url.includes('megagong.net') && r.rank <= 10
+      ).length;
 
       if (megagongResult) {
         foundMegagongRank = megagongResult.rank;
@@ -82,6 +86,7 @@ export default async function handler(req, res) {
       keyword,
       activeRank: foundMegagongRank ? foundMegagongRank : 'N/A',
       sourceUrl: foundMegagongUrl,
+      top10Count: megagongTop10Count,
       results: searchResults,
     });
   } catch (error) {


### PR DESCRIPTION
## Summary
- count megagong.net results appearing in the top 10 search results and return the total
- store the count and show "최고 순위 4위 / 10위내 포함 2건" when multiple hits exist

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*
- `npm run lint` *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a6bbec453483249d432153b0254000