### PR TITLE
Add donut chart view for SEO rank averages

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -283,7 +283,6 @@ export default function Home() {
   const allSeoData = useSeoDataRealtime();
   const seoEntries = useMemo(() => Object.entries(allSeoData), [allSeoData]);
   const [chartLimit, setChartLimit] = useState(7);
-  const [chartType, setChartType] = useState('line');
   const [openCards, setOpenCards] = useState({});
 
   const {
@@ -702,66 +701,58 @@ export default function Home() {
         ) : (
           <>
             {gongChartOptions && sobangChartOptions && (
-              <div className={styles.chartSection}>
-                <div className={styles.chartControls}>
-                  <div className={styles.chartTypeButtons}>
-                    <button
-                      type='button'
-                      className={
-                        chartType === 'line' ? styles.chartTypeActive : ''
-                      }
-                      onClick={() => setChartType('line')}
-                    >
-                      라인차트
-                    </button>
-                    <button
-                      type='button'
-                      className={
-                        chartType === 'donut' ? styles.chartTypeActive : ''
-                      }
-                      onClick={() => setChartType('donut')}
-                    >
-                      도넛차트
-                    </button>
+              <>
+                <div className={styles.chartSection}>
+                  <div className={styles.chartControls}>
+                    <label>
+                      최근
+                      <select
+                        value={chartLimit}
+                        onChange={(e) => setChartLimit(Number(e.target.value))}
+                      >
+                        {[7, 30, 60].map((n) => (
+                          <option key={n} value={n}>
+                            {n}
+                          </option>
+                        ))}
+                      </select>
+                      건
+                    </label>
                   </div>
-                  <label>
-                    최근
-                    <select
-                      value={chartLimit}
-                      onChange={(e) => setChartLimit(Number(e.target.value))}
-                    >
-                      {[7, 30, 60].map((n) => (
-                        <option key={n} value={n}>
-                          {n}
-                        </option>
-                      ))}
-                    </select>
-                    건
-                  </label>
+                  <h4 className={styles.chartSectionTitle}>도넛차트</h4>
+                  <div className={styles.chartGroup}>
+                    <h5 className={styles.chartTitle}>공무원</h5>
+                    <ReactECharts
+                      className={styles.chart}
+                      option={gongDonutOptions}
+                    />
+                  </div>
+                  <div className={styles.chartGroup}>
+                    <h5 className={styles.chartTitle}>소방</h5>
+                    <ReactECharts
+                      className={styles.chart}
+                      option={sobangDonutOptions}
+                    />
+                  </div>
                 </div>
-                <div className={styles.chartGroup}>
-                  <h4 className={styles.chartTitle}>공무원</h4>
-                  <ReactECharts
-                    className={styles.chart}
-                    option={
-                      chartType === 'line'
-                        ? gongChartOptions
-                        : gongDonutOptions
-                    }
-                  />
+                <div className={styles.chartSection}>
+                  <h4 className={styles.chartSectionTitle}>라인차트</h4>
+                  <div className={styles.chartGroup}>
+                    <h5 className={styles.chartTitle}>공무원</h5>
+                    <ReactECharts
+                      className={styles.chart}
+                      option={gongChartOptions}
+                    />
+                  </div>
+                  <div className={styles.chartGroup}>
+                    <h5 className={styles.chartTitle}>소방</h5>
+                    <ReactECharts
+                      className={styles.chart}
+                      option={sobangChartOptions}
+                    />
+                  </div>
                 </div>
-                <div className={styles.chartGroup}>
-                  <h4 className={styles.chartTitle}>소방</h4>
-                  <ReactECharts
-                    className={styles.chart}
-                    option={
-                      chartType === 'line'
-                        ? sobangChartOptions
-                        : sobangDonutOptions
-                    }
-                  />
-                </div>
-              </div>
+              </>
             )}
             <div className={styles.savedGrid}>
               {seoEntries.map(([d, details], idx) => {

--- a/src/app/page.module.scss
+++ b/src/app/page.module.scss
@@ -300,26 +300,9 @@
 
       .chartControls {
         display: flex;
-        justify-content: space-between;
+        justify-content: flex-end;
         align-items: center;
         margin-bottom: 8px;
-
-        .chartTypeButtons {
-          display: flex;
-          gap: 8px;
-
-          button {
-            appearance: none;
-            border: none;
-            @include m.soft-border;
-            background: var(--panel);
-            color: var(--text);
-            padding: 4px 10px;
-            border-radius: 6px;
-            cursor: pointer;
-            font-size: 13px;
-          }
-        }
 
         label {
           font-size: 13px;
@@ -335,9 +318,9 @@
         }
       }
 
-      .chartTypeActive {
-        background: linear-gradient(180deg, var(--primary-50), transparent);
-        color: var(--primary);
+      .chartSectionTitle {
+        margin: 6px 0 8px;
+        font-weight: 700;
       }
 
       .chartGroup {

--- a/src/app/page.module.scss
+++ b/src/app/page.module.scss
@@ -300,8 +300,26 @@
 
       .chartControls {
         display: flex;
-        justify-content: flex-end;
+        justify-content: space-between;
+        align-items: center;
         margin-bottom: 8px;
+
+        .chartTypeButtons {
+          display: flex;
+          gap: 8px;
+
+          button {
+            appearance: none;
+            border: none;
+            @include m.soft-border;
+            background: var(--panel);
+            color: var(--text);
+            padding: 4px 10px;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 13px;
+          }
+        }
 
         label {
           font-size: 13px;
@@ -315,6 +333,11 @@
             color: var(--text);
           }
         }
+      }
+
+      .chartTypeActive {
+        background: linear-gradient(180deg, var(--primary-50), transparent);
+        color: var(--primary);
       }
 
       .chartGroup {


### PR DESCRIPTION
## Summary
- Add chart type toggle to switch between line and donut charts
- Compute donut chart data from average ranks over the selected recent entries
- Share recent entry setting across chart types

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive configuration)


------
https://chatgpt.com/codex/tasks/task_e_68a7bdcbed948324b6e104444d133fd9