### PR TITLE
Display donut and line charts in separate sections

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -283,6 +283,7 @@ export default function Home() {
   const allSeoData = useSeoDataRealtime();
   const seoEntries = useMemo(() => Object.entries(allSeoData), [allSeoData]);
   const [chartLimit, setChartLimit] = useState(7);
+  const [chartType, setChartType] = useState('donut');
   const [openCards, setOpenCards] = useState({});
 
   const {
@@ -701,58 +702,73 @@ export default function Home() {
         ) : (
           <>
             {gongChartOptions && sobangChartOptions && (
-              <>
-                <div className={styles.chartSection}>
-                  <div className={styles.chartControls}>
-                    <label>
-                      최근
-                      <select
-                        value={chartLimit}
-                        onChange={(e) => setChartLimit(Number(e.target.value))}
-                      >
-                        {Array.from({ length: 60 }, (_, i) => i + 1).map((n) => (
-                          <option key={n} value={n}>
-                            {n}
-                          </option>
-                        ))}
-                      </select>
-                      건
-                    </label>
-                  </div>
-                  <h4 className={styles.chartSectionTitle}>도넛차트</h4>
-                  <div className={styles.chartGroup}>
-                    <h5 className={styles.chartTitle}>공무원</h5>
-                    <ReactECharts
-                      className={styles.chart}
-                      option={gongDonutOptions}
-                    />
-                  </div>
-                  <div className={styles.chartGroup}>
-                    <h5 className={styles.chartTitle}>소방</h5>
-                    <ReactECharts
-                      className={styles.chart}
-                      option={sobangDonutOptions}
-                    />
+              <div className={styles.chartSection}>
+                <div className={styles.chartControls}>
+                  <label>
+                    최근
+                    <select
+                      value={chartLimit}
+                      onChange={(e) => setChartLimit(Number(e.target.value))}
+                    >
+                      {Array.from({ length: 60 }, (_, i) => i + 1).map((n) => (
+                        <option key={n} value={n}>
+                          {n}
+                        </option>
+                      ))}
+                    </select>
+                    건
+                  </label>
+                  <div className={styles.chartTabs}>
+                    <button
+                      className={`${styles.chartTab} ${chartType === 'donut' ? styles.chartTabActive : ''}`}
+                      onClick={() => setChartType('donut')}
+                    >
+                      도넛차트
+                    </button>
+                    <button
+                      className={`${styles.chartTab} ${chartType === 'line' ? styles.chartTabActive : ''}`}
+                      onClick={() => setChartType('line')}
+                    >
+                      라인차트
+                    </button>
                   </div>
                 </div>
-                <div className={styles.chartSection}>
-                  <h4 className={styles.chartSectionTitle}>라인차트</h4>
-                  <div className={styles.chartGroup}>
-                    <h5 className={styles.chartTitle}>공무원</h5>
-                    <ReactECharts
-                      className={styles.chart}
-                      option={gongChartOptions}
-                    />
-                  </div>
-                  <div className={styles.chartGroup}>
-                    <h5 className={styles.chartTitle}>소방</h5>
-                    <ReactECharts
-                      className={styles.chart}
-                      option={sobangChartOptions}
-                    />
-                  </div>
-                </div>
-              </>
+                {chartType === 'donut' ? (
+                  <>
+                    <div className={styles.chartGroup}>
+                      <h5 className={styles.chartTitle}>공무원</h5>
+                      <ReactECharts
+                        className={styles.chart}
+                        option={gongDonutOptions}
+                      />
+                    </div>
+                    <div className={styles.chartGroup}>
+                      <h5 className={styles.chartTitle}>소방</h5>
+                      <ReactECharts
+                        className={styles.chart}
+                        option={sobangDonutOptions}
+                      />
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <div className={styles.chartGroup}>
+                      <h5 className={styles.chartTitle}>공무원</h5>
+                      <ReactECharts
+                        className={styles.chart}
+                        option={gongChartOptions}
+                      />
+                    </div>
+                    <div className={styles.chartGroup}>
+                      <h5 className={styles.chartTitle}>소방</h5>
+                      <ReactECharts
+                        className={styles.chart}
+                        option={sobangChartOptions}
+                      />
+                    </div>
+                  </>
+                )}
+              </div>
             )}
             <div className={styles.savedGrid}>
               {seoEntries.map(([d, details], idx) => {

--- a/src/app/page.module.scss
+++ b/src/app/page.module.scss
@@ -301,6 +301,7 @@
       .chartControls {
         display: flex;
         justify-content: flex-end;
+        align-items: center;
         margin-bottom: 8px;
 
         label {
@@ -315,6 +316,11 @@
             color: var(--text);
           }
         }
+      }
+
+      .chartSectionTitle {
+        margin: 6px 0 8px;
+        font-weight: 700;
       }
 
       .chartGroup {

--- a/src/app/page.module.scss
+++ b/src/app/page.module.scss
@@ -300,7 +300,7 @@
 
       .chartControls {
         display: flex;
-        justify-content: flex-end;
+        justify-content: space-between;
         align-items: center;
         margin-bottom: 8px;
 
@@ -314,6 +314,38 @@
             border-radius: 6px;
             background: var(--panel);
             color: var(--text);
+          }
+        }
+
+        .chartTabs {
+          display: flex;
+          gap: 8px;
+
+          .chartTab {
+            appearance: none;
+            border: none;
+            @include m.soft-border;
+            background: var(--panel);
+            color: var(--text-sub);
+            cursor: pointer;
+            padding: 4px 8px;
+            border-radius: var(--radius-sm);
+            font-size: 13px;
+            font-weight: 700;
+            transition: background-color 0.2s ease, color 0.2s ease;
+
+            &:hover {
+              opacity: 0.8;
+            }
+
+            &:focus-visible {
+              @include m.focus-ring;
+            }
+          }
+
+          .chartTabActive {
+            background: var(--primary);
+            color: var(--panel);
           }
         }
       }


### PR DESCRIPTION
## Summary
- Separate donut and line charts into their own sections
- Share recent entry selector across both charts
- Allow selecting 1–60 recent entries (default 7) for chart data

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive configuration)


------
https://chatgpt.com/codex/tasks/task_e_68a7bdcbed948324b6e104444d133fd9