### PR TITLE
Toggle between donut and line charts within one card

### DIFF
--- a/src/app/page.module.scss
+++ b/src/app/page.module.scss
@@ -300,7 +300,8 @@
 
       .chartControls {
         display: flex;
-        justify-content: flex-end;
+        justify-content: space-between;
+        align-items: center;
         margin-bottom: 8px;
 
         label {
@@ -315,6 +316,43 @@
             color: var(--text);
           }
         }
+
+        .chartTabs {
+          display: flex;
+          gap: 8px;
+
+          .chartTab {
+            appearance: none;
+            border: none;
+            @include m.soft-border;
+            background: var(--panel);
+            color: var(--text-sub);
+            cursor: pointer;
+            padding: 4px 8px;
+            border-radius: var(--radius-sm);
+            font-size: 13px;
+            font-weight: 700;
+            transition: background-color 0.2s ease, color 0.2s ease;
+
+            &:hover {
+              opacity: 0.8;
+            }
+
+            &:focus-visible {
+              @include m.focus-ring;
+            }
+          }
+
+          .chartTabActive {
+            background: var(--primary);
+            color: var(--panel);
+          }
+        }
+      }
+
+      .chartSectionTitle {
+        margin: 6px 0 8px;
+        font-weight: 700;
       }
 
       .chartGroup {


### PR DESCRIPTION
## Summary
- Place recent-entry selector and chart-type tabs in a single card
- Default to donut charts and toggle to line charts via tab
- Share recent-entry selector across both chart types
- Fix lingering line charts when switching back to donut view by remounting charts

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: prompts for ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_68a7bdcbed948324b6e104444d133fd9