### PR TITLE
feat: add keyword trend modal

### DIFF
--- a/src/app/page.module.scss
+++ b/src/app/page.module.scss
@@ -549,6 +549,65 @@
     }
   }
 
+  .keywordButton {
+    appearance: none;
+    border: none;
+    background: none;
+    padding: 0;
+    cursor: pointer;
+    color: var(--primary);
+    text-decoration: underline;
+    font: inherit;
+  }
+
+  .modalOverlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+  }
+
+  .modalContent {
+    @include m.card;
+    background: var(--panel);
+    padding: 20px;
+    max-width: 600px;
+    width: 90%;
+  }
+
+  .modalTitle {
+    margin: 0 0 12px;
+    font-weight: 700;
+  }
+
+  .modalChart {
+    width: 100%;
+    height: 300px;
+  }
+
+  .modalClose {
+    margin-top: 12px;
+    appearance: none;
+    border: none;
+    @include m.soft-border;
+    background: var(--primary);
+    color: var(--panel);
+    padding: 6px 12px;
+    border-radius: var(--radius-sm);
+    font-weight: 700;
+    cursor: pointer;
+
+    &:hover {
+      opacity: 0.9;
+    }
+  }
+
   .note {
     margin-top: 8px;
     padding: 10px 12px;


### PR DESCRIPTION
## Summary
- open saved keywords in a modal line chart when clicked
- add styling for keyword buttons and modal display

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(warning about Next.js ESLint plugin, process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ca3f6dbc8324939ec4d78a75157e