### PR TITLE
Sort saved keyword rankings by defined order

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -869,10 +869,11 @@ export default function Home() {
                                 </tr>
                               </thead>
                               <tbody>
-                                {Object.entries(gong).map(([kw, r]) => {
+                                {gongKeywords.map((kw) => {
+                                  const r = gong[kw];
                                   const value = getRankValue(r);
                                   const src =
-                                    typeof r === 'object' && r.source
+                                    typeof r === 'object' && r?.source
                                       ? r.source
                                       : '';
                                   const prevValue = prevGong[kw];
@@ -937,10 +938,11 @@ export default function Home() {
                                 </tr>
                               </thead>
                               <tbody>
-                                {Object.entries(sobang).map(([kw, r]) => {
+                                {sobangKeywords.map((kw) => {
+                                  const r = sobang[kw];
                                   const value = getRankValue(r);
                                   const src =
-                                    typeof r === 'object' && r.source
+                                    typeof r === 'object' && r?.source
                                       ? r.source
                                       : '';
                                   const prevValue = prevSobang[kw];


### PR DESCRIPTION
## Summary
- Display saved rankings using `gongKeywords` and `sobangKeywords` order

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive prompt prevented completion)*

------
https://chatgpt.com/codex/tasks/task_e_68a80e4f37d883249cc101745b56dd84