### PR TITLE
feat: manage keywords in firebase

### DIFF
--- a/src/app/keywords/page.js
+++ b/src/app/keywords/page.js
@@ -1,0 +1,124 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { doc, onSnapshot, setDoc } from 'firebase/firestore';
+import { db } from '@/firebaseClient';
+import styles from './page.module.scss';
+
+export default function KeywordManager() {
+  const [gong, setGong] = useState([]);
+  const [sobang, setSobang] = useState([]);
+  const [newGong, setNewGong] = useState('');
+  const [newSobang, setNewSobang] = useState('');
+  const [drag, setDrag] = useState(null);
+
+  useEffect(() => {
+    if (!db) return;
+    const unsubG = onSnapshot(doc(db, 'keywords', 'gong'), (snap) => {
+      setGong(snap.data()?.list || []);
+    });
+    const unsubS = onSnapshot(doc(db, 'keywords', 'sobang'), (snap) => {
+      setSobang(snap.data()?.list || []);
+    });
+    return () => {
+      unsubG();
+      unsubS();
+    };
+  }, []);
+
+  const update = async (group, arr) => {
+    if (!db) return;
+    await setDoc(doc(db, 'keywords', group), { list: arr });
+  };
+
+  const add = async (group) => {
+    const value = group === 'gong' ? newGong.trim() : newSobang.trim();
+    if (!value) return;
+    const arr = group === 'gong' ? [...gong, value] : [...sobang, value];
+    await update(group, arr);
+    if (group === 'gong') setNewGong('');
+    else setNewSobang('');
+  };
+
+  const remove = async (group, index) => {
+    const arr = group === 'gong' ? [...gong] : [...sobang];
+    arr.splice(index, 1);
+    await update(group, arr);
+  };
+
+  const onDragStart = (group, index) => {
+    setDrag({ group, index });
+  };
+
+  const onDrop = async (group, index) => {
+    if (!drag || drag.group !== group) return setDrag(null);
+    const arr = group === 'gong' ? [...gong] : [...sobang];
+    const [moved] = arr.splice(drag.index, 1);
+    arr.splice(index, 0, moved);
+    setDrag(null);
+    await update(group, arr);
+  };
+
+  return (
+    <div className={styles.container}>
+      <h1>키워드 관리자</h1>
+      <div className={styles.group}>
+        <h2 className={styles.groupTitle}>공무원</h2>
+        <ul className={styles.list}>
+          {gong.map((kw, idx) => (
+            <li
+              key={kw}
+              className={styles.item}
+              draggable
+              onDragStart={() => onDragStart('gong', idx)}
+              onDragOver={(e) => e.preventDefault()}
+              onDrop={() => onDrop('gong', idx)}
+            >
+              <span>{kw}</span>
+              <button onClick={() => remove('gong', idx)}>삭제</button>
+            </li>
+          ))}
+        </ul>
+        <div className={styles.controls}>
+          <input
+            value={newGong}
+            onChange={(e) => setNewGong(e.target.value)}
+            placeholder='키워드 추가'
+          />
+          <button onClick={() => add('gong')}>추가</button>
+        </div>
+      </div>
+      <div className={styles.group}>
+        <h2 className={styles.groupTitle}>소방</h2>
+        <ul className={styles.list}>
+          {sobang.map((kw, idx) => (
+            <li
+              key={kw}
+              className={styles.item}
+              draggable
+              onDragStart={() => onDragStart('sobang', idx)}
+              onDragOver={(e) => e.preventDefault()}
+              onDrop={() => onDrop('sobang', idx)}
+            >
+              <span>{kw}</span>
+              <button onClick={() => remove('sobang', idx)}>삭제</button>
+            </li>
+          ))}
+        </ul>
+        <div className={styles.controls}>
+          <input
+            value={newSobang}
+            onChange={(e) => setNewSobang(e.target.value)}
+            placeholder='키워드 추가'
+          />
+          <button onClick={() => add('sobang')}>추가</button>
+        </div>
+      </div>
+      <Link href='/' className={styles.backLink}>
+        메인으로
+      </Link>
+    </div>
+  );
+}
+

--- a/src/app/keywords/page.module.scss
+++ b/src/app/keywords/page.module.scss
@@ -1,0 +1,54 @@
+@use '@/styles/mixins' as m;
+
+.container {
+  max-width: 800px;
+  margin: 20px auto;
+  padding: 20px;
+  color: var(--text);
+}
+
+.group {
+  margin-top: 32px;
+}
+
+.groupTitle {
+  margin: 0 0 12px;
+  font-weight: 700;
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 12px;
+}
+
+.item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.controls {
+  display: flex;
+  gap: 8px;
+
+  input {
+    flex: 1;
+    padding: 6px;
+    border: 1px solid var(--line);
+    border-radius: 4px;
+  }
+
+  button {
+    padding: 6px 12px;
+  }
+}
+
+.backLink {
+  display: inline-block;
+  margin-top: 20px;
+  color: var(--primary);
+  text-decoration: none;
+}

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import styles from '@/styles/header.module.scss';
 
@@ -29,34 +30,39 @@ export default function Header() {
         ) : (
           <img src='/images/logo.png' alt='Nextstudy logo' />
         )}
-        <button onClick={toggleTheme} aria-label='Toggle theme'>
-          {theme === 'light' ? (
-            <svg
-              xmlns='http://www.w3.org/2000/svg'
-              viewBox='0 0 24 24'
-              fill='none'
-              stroke='currentColor'
-              strokeWidth='2'
-              strokeLinecap='round'
-              strokeLinejoin='round'
-            >
-              <path d='M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z' />
-            </svg>
-          ) : (
-            <svg
-              xmlns='http://www.w3.org/2000/svg'
-              viewBox='0 0 24 24'
-              fill='none'
-              stroke='currentColor'
-              strokeWidth='2'
-              strokeLinecap='round'
-              strokeLinejoin='round'
-            >
-              <circle cx='12' cy='12' r='5' />
-              <path d='M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42' />
-            </svg>
-          )}
-        </button>
+        <div className={styles.controls}>
+          <Link href='/keywords' className={styles.managerLink}>
+            키워드 관리자
+          </Link>
+          <button onClick={toggleTheme} aria-label='Toggle theme'>
+            {theme === 'light' ? (
+              <svg
+                xmlns='http://www.w3.org/2000/svg'
+                viewBox='0 0 24 24'
+                fill='none'
+                stroke='currentColor'
+                strokeWidth='2'
+                strokeLinecap='round'
+                strokeLinejoin='round'
+              >
+                <path d='M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z' />
+              </svg>
+            ) : (
+              <svg
+                xmlns='http://www.w3.org/2000/svg'
+                viewBox='0 0 24 24'
+                fill='none'
+                stroke='currentColor'
+                strokeWidth='2'
+                strokeLinecap='round'
+                strokeLinejoin='round'
+              >
+                <circle cx='12' cy='12' r='5' />
+                <path d='M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42' />
+              </svg>
+            )}
+          </button>
+        </div>
       </div>
     </header>
   );

--- a/src/firebaseClient.js
+++ b/src/firebaseClient.js
@@ -1,0 +1,21 @@
+import { initializeApp, getApps } from 'firebase/app';
+import { getFirestore } from 'firebase/firestore';
+
+const firebaseConfig = {
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+};
+
+let db = null;
+if (typeof window !== 'undefined') {
+  if (!getApps().length) {
+    initializeApp(firebaseConfig);
+  }
+  db = getFirestore();
+}
+
+export { db };

--- a/src/styles/header.module.scss
+++ b/src/styles/header.module.scss
@@ -13,3 +13,15 @@
     padding: 0 14px;
   }
 }
+
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+
+  .managerLink {
+    text-decoration: none;
+    color: var(--text);
+    font-weight: 600;
+  }
+}


### PR DESCRIPTION
## Summary
- load keyword lists from Firestore instead of hardcoded arrays
- add keyword manager page to add, delete, and reorder keywords
- expose keyword manager link in header

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: prompts for ESLint setup)

------
https://chatgpt.com/codex/tasks/task_e_68a8159b7a7c832482b70397d5db5b7a