### PR TITLE
feat: dark mode support and relaxed date constraint

### DIFF
--- a/src/app/keywords/page.module.scss
+++ b/src/app/keywords/page.module.scss
@@ -1,10 +1,13 @@
 @use '@/styles/mixins' as m;
 
 .container {
-  max-width: 900px;
+  max-width: 1100px;
   margin: 20px auto;
-  padding: 20px;
+  padding: 28px;
   color: var(--text);
+  @media (max-width: 640px) {
+    padding: 28px 14px;
+  }
 }
 
 .groups {


### PR DESCRIPTION
## Summary
- support dark mode by updating chart legends, axes, and tooltips to use theme colors
- allow saving SEO data on any date instead of limiting to Fridays

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68a82dd285c8832496dec78156acfb40