### PR TITLE
feat: add login and signup with email and google auth

### DIFF
--- a/src/app/login/page.js
+++ b/src/app/login/page.js
@@ -1,5 +1,19 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { onAuthStateChanged } from 'firebase/auth';
+import { auth } from '@/firebaseClient';
 import AuthForm from '@/components/AuthForm';
 
 export default function LoginPage() {
+  const router = useRouter();
+  useEffect(() => {
+    const unsub = onAuthStateChanged(auth, (user) => {
+      if (user) router.replace('/');
+    });
+    return () => unsub();
+  }, [router]);
+
   return <AuthForm mode='login' />;
 }

--- a/src/app/login/page.js
+++ b/src/app/login/page.js
@@ -1,0 +1,5 @@
+import AuthForm from '@/components/AuthForm';
+
+export default function LoginPage() {
+  return <AuthForm mode='login' />;
+}

--- a/src/app/signup/page.js
+++ b/src/app/signup/page.js
@@ -1,0 +1,5 @@
+import AuthForm from '@/components/AuthForm';
+
+export default function SignupPage() {
+  return <AuthForm mode='signup' />;
+}

--- a/src/app/signup/page.js
+++ b/src/app/signup/page.js
@@ -1,5 +1,19 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { onAuthStateChanged } from 'firebase/auth';
+import { auth } from '@/firebaseClient';
 import AuthForm from '@/components/AuthForm';
 
 export default function SignupPage() {
+  const router = useRouter();
+  useEffect(() => {
+    const unsub = onAuthStateChanged(auth, (user) => {
+      if (user) router.replace('/');
+    });
+    return () => unsub();
+  }, [router]);
+
   return <AuthForm mode='signup' />;
 }

--- a/src/components/AuthForm.js
+++ b/src/components/AuthForm.js
@@ -1,0 +1,79 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { auth, googleProvider } from '@/firebaseClient';
+import {
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
+  signInWithPopup,
+} from 'firebase/auth';
+
+export default function AuthForm({ mode }) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const router = useRouter();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    try {
+      if (mode === 'login') {
+        await signInWithEmailAndPassword(auth, email, password);
+      } else {
+        await createUserWithEmailAndPassword(auth, email, password);
+      }
+      router.push('/');
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  const handleGoogle = async () => {
+    setError('');
+    try {
+      await signInWithPopup(auth, googleProvider);
+      router.push('/');
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <div style={{ maxWidth: '400px', margin: '0 auto' }}>
+      <h1>{mode === 'login' ? '로그인' : '회원가입'}</h1>
+      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+        <input
+          type='email'
+          placeholder='이메일'
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <input
+          type='password'
+          placeholder='비밀번호'
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        <button type='submit'>{mode === 'login' ? '로그인' : '회원가입'}</button>
+      </form>
+      <button onClick={handleGoogle} style={{ marginTop: '12px' }}>
+        Google로 {mode === 'login' ? '로그인' : '회원가입'}
+      </button>
+      {error && <p style={{ color: 'red', marginTop: '8px' }}>{error}</p>}
+      {mode === 'login' ? (
+        <p style={{ marginTop: '8px' }}>
+          계정이 없나요? <Link href='/signup'>회원가입</Link>
+        </p>
+      ) : (
+        <p style={{ marginTop: '8px' }}>
+          이미 계정이 있나요? <Link href='/login'>로그인</Link>
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/AuthForm.js
+++ b/src/components/AuthForm.js
@@ -10,6 +10,7 @@ import {
   signInWithPopup,
   updateProfile,
 } from 'firebase/auth';
+import styles from './AuthForm.module.scss';
 
 export default function AuthForm({ mode }) {
   const [email, setEmail] = useState('');
@@ -45,10 +46,11 @@ export default function AuthForm({ mode }) {
   };
 
   return (
-    <div style={{ maxWidth: '400px', margin: '0 auto' }}>
-      <h1>{mode === 'login' ? '로그인' : '회원가입'}</h1>
-      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+    <div className={styles.container}>
+      <h1 className={styles.title}>{mode === 'login' ? '로그인' : '회원가입'}</h1>
+      <form onSubmit={handleSubmit} className={styles.form}>
         <input
+          className={styles.input}
           type='email'
           placeholder='이메일'
           value={email}
@@ -56,6 +58,7 @@ export default function AuthForm({ mode }) {
           required
         />
         <input
+          className={styles.input}
           type='password'
           placeholder='비밀번호'
           value={password}
@@ -64,6 +67,7 @@ export default function AuthForm({ mode }) {
         />
         {mode === 'signup' && (
           <input
+            className={styles.input}
             type='text'
             placeholder='닉네임'
             value={nickname}
@@ -71,18 +75,20 @@ export default function AuthForm({ mode }) {
             required
           />
         )}
-        <button type='submit'>{mode === 'login' ? '로그인' : '회원가입'}</button>
+        <button type='submit' className={styles.submitButton}>
+          {mode === 'login' ? '로그인' : '회원가입'}
+        </button>
       </form>
-      <button onClick={handleGoogle} style={{ marginTop: '12px' }}>
+      <button onClick={handleGoogle} className={styles.googleButton}>
         Google로 {mode === 'login' ? '로그인' : '회원가입'}
       </button>
-      {error && <p style={{ color: 'red', marginTop: '8px' }}>{error}</p>}
+      {error && <p className={styles.error}>{error}</p>}
       {mode === 'login' ? (
-        <p style={{ marginTop: '8px' }}>
+        <p className={styles.switch}>
           계정이 없나요? <Link href='/signup'>회원가입</Link>
         </p>
       ) : (
-        <p style={{ marginTop: '8px' }}>
+        <p className={styles.switch}>
           이미 계정이 있나요? <Link href='/login'>로그인</Link>
         </p>
       )}

--- a/src/components/AuthForm.js
+++ b/src/components/AuthForm.js
@@ -8,11 +8,13 @@ import {
   signInWithEmailAndPassword,
   createUserWithEmailAndPassword,
   signInWithPopup,
+  updateProfile,
 } from 'firebase/auth';
 
 export default function AuthForm({ mode }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [nickname, setNickname] = useState('');
   const [error, setError] = useState('');
   const router = useRouter();
 
@@ -23,7 +25,8 @@ export default function AuthForm({ mode }) {
       if (mode === 'login') {
         await signInWithEmailAndPassword(auth, email, password);
       } else {
-        await createUserWithEmailAndPassword(auth, email, password);
+        const cred = await createUserWithEmailAndPassword(auth, email, password);
+        await updateProfile(cred.user, { displayName: nickname });
       }
       router.push('/');
     } catch (err) {
@@ -59,6 +62,15 @@ export default function AuthForm({ mode }) {
           onChange={(e) => setPassword(e.target.value)}
           required
         />
+        {mode === 'signup' && (
+          <input
+            type='text'
+            placeholder='닉네임'
+            value={nickname}
+            onChange={(e) => setNickname(e.target.value)}
+            required
+          />
+        )}
         <button type='submit'>{mode === 'login' ? '로그인' : '회원가입'}</button>
       </form>
       <button onClick={handleGoogle} style={{ marginTop: '12px' }}>

--- a/src/components/AuthForm.module.scss
+++ b/src/components/AuthForm.module.scss
@@ -1,0 +1,55 @@
+.container {
+  max-width: 400px;
+  margin: 80px auto;
+  padding: 32px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+}
+
+.title {
+  text-align: center;
+  margin-bottom: 16px;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.input {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 8px 12px;
+  background: var(--bg);
+}
+
+.submitButton {
+  background: var(--primary);
+  color: #fff;
+  padding: 10px;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+}
+
+.googleButton {
+  margin-top: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 10px;
+}
+
+.error {
+  color: var(--warning);
+  margin-top: 8px;
+  text-align: center;
+}
+
+.switch {
+  margin-top: 8px;
+  text-align: center;
+}

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
-import { onAuthStateChanged } from 'firebase/auth';
+import { onAuthStateChanged, signOut } from 'firebase/auth';
 import { auth } from '@/firebaseClient';
 import styles from '@/styles/header.module.scss';
 
@@ -25,6 +25,10 @@ export default function Header() {
     setTheme(next);
     document.documentElement.setAttribute('data-theme', next);
     localStorage.setItem('theme', next);
+  };
+
+  const handleLogout = () => {
+    signOut(auth);
   };
 
   const adminEmail = process.env.NEXT_PUBLIC_ADMIN_EMAIL;
@@ -51,6 +55,9 @@ export default function Header() {
                 {user.email}
                 {user.displayName ? `(${user.displayName})` : ''}님 반갑습니다.
               </span>
+              <button onClick={handleLogout} className={styles.logout}>
+                로그아웃
+              </button>
             </>
           ) : (
             <>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -36,6 +36,9 @@ export default function Header() {
           <Link href='/keywords' className={styles.managerLink}>
             키워드 관리자
           </Link>
+          <Link href='/login' className={styles.managerLink}>
+            로그인
+          </Link>
           <button onClick={toggleTheme} aria-label='Toggle theme'>
             {theme === 'light' ? (
               <svg

--- a/src/firebaseClient.js
+++ b/src/firebaseClient.js
@@ -1,4 +1,5 @@
 import { initializeApp, getApps } from 'firebase/app';
+import { getAuth, GoogleAuthProvider } from 'firebase/auth';
 import { getFirestore } from 'firebase/firestore';
 
 const firebaseConfig = {
@@ -10,12 +11,20 @@ const firebaseConfig = {
   appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
 };
 
+let app = null;
+let auth = null;
+let googleProvider = null;
 let db = null;
+
 if (typeof window !== 'undefined') {
   if (!getApps().length) {
-    initializeApp(firebaseConfig);
+    app = initializeApp(firebaseConfig);
+  } else {
+    app = getApps()[0];
   }
-  db = getFirestore();
+  auth = getAuth(app);
+  googleProvider = new GoogleAuthProvider();
+  db = getFirestore(app);
 }
 
-export { db };
+export { db, auth, googleProvider };

--- a/src/styles/header.module.scss
+++ b/src/styles/header.module.scss
@@ -29,4 +29,12 @@
     font-weight: 600;
     color: var(--text);
   }
+
+  .logout {
+    padding: 0.25rem 0.75rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--panel);
+    color: var(--text);
+  }
 }

--- a/src/styles/header.module.scss
+++ b/src/styles/header.module.scss
@@ -24,4 +24,9 @@
     color: var(--text);
     font-weight: 600;
   }
+
+  .welcome {
+    font-weight: 600;
+    color: var(--text);
+  }
 }


### PR DESCRIPTION
## Summary
- enable Firebase auth with email/password and Google provider
- add reusable AuthForm component with email and Google login/signup
- create login and signup pages and link from header

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: requires interactive ESLint setup)


------
https://chatgpt.com/codex/tasks/task_e_68abb4f220488324bb51f29e8a10f311