### PR TITLE
feat: add email verification on signup

### DIFF
--- a/src/app/login/page.js
+++ b/src/app/login/page.js
@@ -10,7 +10,7 @@ export default function LoginPage() {
   const router = useRouter();
   useEffect(() => {
     const unsub = onAuthStateChanged(auth, (user) => {
-      if (user) router.replace('/');
+      if (user && user.emailVerified) router.replace('/');
     });
     return () => unsub();
   }, [router]);

--- a/src/app/signup/page.js
+++ b/src/app/signup/page.js
@@ -1,19 +1,7 @@
 'use client';
 
-import { useEffect } from 'react';
-import { useRouter } from 'next/navigation';
-import { onAuthStateChanged } from 'firebase/auth';
-import { auth } from '@/firebaseClient';
 import AuthForm from '@/components/AuthForm';
 
 export default function SignupPage() {
-  const router = useRouter();
-  useEffect(() => {
-    const unsub = onAuthStateChanged(auth, (user) => {
-      if (user?.emailVerified) router.replace('/');
-    });
-    return () => unsub();
-  }, [router]);
-
   return <AuthForm mode='signup' />;
 }

--- a/src/app/signup/page.js
+++ b/src/app/signup/page.js
@@ -10,7 +10,7 @@ export default function SignupPage() {
   const router = useRouter();
   useEffect(() => {
     const unsub = onAuthStateChanged(auth, (user) => {
-      if (user) router.replace('/');
+      if (user?.emailVerified) router.replace('/');
     });
     return () => unsub();
   }, [router]);

--- a/src/components/AuthForm.js
+++ b/src/components/AuthForm.js
@@ -34,18 +34,26 @@ export default function AuthForm({ mode }) {
     try {
       if (mode === 'login') {
         await signInWithEmailAndPassword(auth, email, password);
-        router.push('/');
+        // router.push('/');
+        console.log(111);
       } else {
-        const cred = await createUserWithEmailAndPassword(auth, email, password);
+        console.log(222);
+        const cred = await createUserWithEmailAndPassword(
+          auth,
+          email,
+          password
+        );
         await updateProfile(cred.user, { displayName: nickname });
         await sendEmailVerification(cred.user);
         setVerificationSent(true);
+        console.log(333);
         intervalRef.current = setInterval(async () => {
           try {
             await auth.currentUser.reload();
             if (auth.currentUser.emailVerified) {
               clearInterval(intervalRef.current);
-              router.push('/');
+              // router.push('/');
+              console.log(444);
             }
           } catch (err) {
             setError(err.message);
@@ -61,7 +69,7 @@ export default function AuthForm({ mode }) {
     setError('');
     try {
       await signInWithPopup(auth, googleProvider);
-      router.push('/');
+      // router.push('/');
     } catch (err) {
       setError(err.message);
     }
@@ -81,7 +89,9 @@ export default function AuthForm({ mode }) {
 
   return (
     <div className={styles.container}>
-      <h1 className={styles.title}>{mode === 'login' ? '로그인' : '회원가입'}</h1>
+      <h1 className={styles.title}>
+        {mode === 'login' ? '로그인' : '회원가입'}
+      </h1>
       {verificationSent && mode === 'signup' ? (
         <>
           <p className={styles.notice}>

--- a/src/components/AuthForm.js
+++ b/src/components/AuthForm.js
@@ -40,8 +40,8 @@ export default function AuthForm({ mode }) {
         const cred = await createUserWithEmailAndPassword(auth, email, password);
         await updateProfile(cred.user, { displayName: nickname });
         await sendEmailVerification(cred.user);
-        setVerificationSent(true);
         await signOut(auth);
+        setVerificationSent(true);
         intervalRef.current = setInterval(async () => {
           try {
             const c = await signInWithEmailAndPassword(auth, email, password);

--- a/src/components/AuthForm.js
+++ b/src/components/AuthForm.js
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { auth, googleProvider } from '@/firebaseClient';
@@ -9,6 +9,7 @@ import {
   createUserWithEmailAndPassword,
   signInWithPopup,
   updateProfile,
+  sendEmailVerification,
 } from 'firebase/auth';
 import styles from './AuthForm.module.scss';
 
@@ -17,7 +18,15 @@ export default function AuthForm({ mode }) {
   const [password, setPassword] = useState('');
   const [nickname, setNickname] = useState('');
   const [error, setError] = useState('');
+  const [verificationSent, setVerificationSent] = useState(false);
+  const intervalRef = useRef(null);
   const router = useRouter();
+
+  useEffect(() => {
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, []);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -25,11 +34,20 @@ export default function AuthForm({ mode }) {
     try {
       if (mode === 'login') {
         await signInWithEmailAndPassword(auth, email, password);
+        router.push('/');
       } else {
         const cred = await createUserWithEmailAndPassword(auth, email, password);
         await updateProfile(cred.user, { displayName: nickname });
+        await sendEmailVerification(cred.user);
+        setVerificationSent(true);
+        intervalRef.current = setInterval(async () => {
+          await cred.user.reload();
+          if (cred.user.emailVerified) {
+            clearInterval(intervalRef.current);
+            router.push('/');
+          }
+        }, 3000);
       }
-      router.push('/');
     } catch (err) {
       setError(err.message);
     }
@@ -45,40 +63,60 @@ export default function AuthForm({ mode }) {
     }
   };
 
+  const handleResend = async () => {
+    setError('');
+    try {
+      if (auth.currentUser) await sendEmailVerification(auth.currentUser);
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
   return (
     <div className={styles.container}>
       <h1 className={styles.title}>{mode === 'login' ? '로그인' : '회원가입'}</h1>
-      <form onSubmit={handleSubmit} className={styles.form}>
-        <input
-          className={styles.input}
-          type='email'
-          placeholder='이메일'
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          required
-        />
-        <input
-          className={styles.input}
-          type='password'
-          placeholder='비밀번호'
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          required
-        />
-        {mode === 'signup' && (
+      {verificationSent && mode === 'signup' ? (
+        <>
+          <p className={styles.notice}>
+            인증 이메일이 발송되었습니다. 이메일을 확인해주세요.
+          </p>
+          <button onClick={handleResend} className={styles.submitButton}>
+            이메일 다시 보내기
+          </button>
+        </>
+      ) : (
+        <form onSubmit={handleSubmit} className={styles.form}>
           <input
             className={styles.input}
-            type='text'
-            placeholder='닉네임'
-            value={nickname}
-            onChange={(e) => setNickname(e.target.value)}
+            type='email'
+            placeholder='이메일'
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
             required
           />
-        )}
-        <button type='submit' className={styles.submitButton}>
-          {mode === 'login' ? '로그인' : '회원가입'}
-        </button>
-      </form>
+          <input
+            className={styles.input}
+            type='password'
+            placeholder='비밀번호'
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+          {mode === 'signup' && (
+            <input
+              className={styles.input}
+              type='text'
+              placeholder='닉네임'
+              value={nickname}
+              onChange={(e) => setNickname(e.target.value)}
+              required
+            />
+          )}
+          <button type='submit' className={styles.submitButton}>
+            {mode === 'login' ? '로그인' : '회원가입'}
+          </button>
+        </form>
+      )}
       <button onClick={handleGoogle} className={styles.googleButton}>
         Google로 {mode === 'login' ? '로그인' : '회원가입'}
       </button>

--- a/src/components/AuthForm.module.scss
+++ b/src/components/AuthForm.module.scss
@@ -53,3 +53,8 @@
   margin-top: 8px;
   text-align: center;
 }
+
+.notice {
+  text-align: center;
+  margin-top: 8px;
+}


### PR DESCRIPTION
## Summary
- stay on signup page until email verified
- auto redirect to main page after verification
- allow resending verification email

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68abdf5c379c8324b0289d505fc6e9e3