### PR TITLE
Refactor auth flow to fix logout redirect

### DIFF
--- a/src/app/login/page.js
+++ b/src/app/login/page.js
@@ -8,12 +8,13 @@ import AuthForm from '@/components/AuthForm';
 
 export default function LoginPage() {
   const router = useRouter();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     const unsub = onAuthStateChanged(auth, (user) => {
       if (user && user.emailVerified) router.replace('/');
     });
     return () => unsub();
-  }, [router]);
+  }, []);
 
   return <AuthForm mode='login' />;
 }

--- a/src/app/signup/page.js
+++ b/src/app/signup/page.js
@@ -1,7 +1,21 @@
 'use client';
 
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { onAuthStateChanged } from 'firebase/auth';
+import { auth } from '@/firebaseClient';
 import AuthForm from '@/components/AuthForm';
 
 export default function SignupPage() {
+  const router = useRouter();
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    const unsub = onAuthStateChanged(auth, (user) => {
+      if (user && user.emailVerified) router.replace('/');
+    });
+    return () => unsub();
+  }, []);
+
   return <AuthForm mode='signup' />;
 }


### PR DESCRIPTION
## Summary
- simplify header auth state handling and remove redirect side effects
- handle auth redirects in login/signup pages and avoid router-based resubscriptions

## Testing
- `npm run lint` *(fails: project prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68abfe4415b48324bf0580ac2f403979