### PR TITLE
feat: add keyword admin permissions

### DIFF
--- a/src/app/admin/page.js
+++ b/src/app/admin/page.js
@@ -1,0 +1,102 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import {
+  collection,
+  doc,
+  getDocs,
+  onSnapshot,
+  setDoc,
+  arrayUnion,
+  arrayRemove,
+} from 'firebase/firestore';
+import { db } from '@/firebaseClient';
+import { useAuth } from '@/context/AuthContext';
+
+export default function AdminPage() {
+  const { user } = useAuth();
+  const router = useRouter();
+  const adminEmail = process.env.NEXT_PUBLIC_ADMIN_EMAIL;
+  const [users, setUsers] = useState([]);
+  const [selected, setSelected] = useState('');
+  const [managers, setManagers] = useState([]);
+
+  useEffect(() => {
+    if (!user) return;
+    if (user.email !== adminEmail) router.replace('/');
+  }, [user, adminEmail, router]);
+
+  useEffect(() => {
+    const fetchUsers = async () => {
+      const snap = await getDocs(collection(db, 'users'));
+      setUsers(snap.docs.map((d) => ({ id: d.id, ...d.data() })));
+    };
+    fetchUsers();
+    const unsub = onSnapshot(doc(db, 'permissions', 'keywordManagers'), (snap) => {
+      setManagers(snap.data()?.uids || []);
+    });
+    return () => unsub();
+  }, []);
+
+  const handleAdd = async () => {
+    if (!selected) return;
+    await setDoc(
+      doc(db, 'permissions', 'keywordManagers'),
+      { uids: arrayUnion(selected) },
+      { merge: true }
+    );
+    setSelected('');
+  };
+
+  const handleRemove = async (uid) => {
+    await setDoc(
+      doc(db, 'permissions', 'keywordManagers'),
+      { uids: arrayRemove(uid) },
+      { merge: true }
+    );
+  };
+
+  const managerUsers = users.filter((u) => managers.includes(u.id));
+
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>권한 설정</h1>
+      <div style={{ marginBottom: '1rem' }}>
+        <select
+          value={selected}
+          onChange={(e) => setSelected(e.target.value)}
+          style={{ marginRight: '0.5rem' }}
+        >
+          <option value=''>회원 선택</option>
+          {users.map((u) => (
+            <option key={u.id} value={u.id}>
+              {u.email}
+              {u.displayName ? `(${u.displayName})` : ''}
+            </option>
+          ))}
+        </select>
+        <button onClick={handleAdd}>권한 부여</button>
+      </div>
+      <ul>
+        {managerUsers.map((u) => (
+          <li key={u.id} style={{ marginBottom: '0.5rem' }}>
+            {u.email}
+            {u.displayName ? `(${u.displayName})` : ''}
+            <button
+              style={{ marginLeft: '0.5rem' }}
+              onClick={() => handleRemove(u.id)}
+            >
+              삭제
+            </button>
+          </li>
+        ))}
+      </ul>
+      <Link href='/' style={{ display: 'inline-block', marginTop: '1rem' }}>
+        메인으로
+      </Link>
+    </div>
+  );
+}
+

--- a/src/app/keywords/page.js
+++ b/src/app/keywords/page.js
@@ -2,11 +2,15 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import useKeywordPermission from '@/hooks/useKeywordPermission';
 import { doc, onSnapshot, setDoc } from 'firebase/firestore';
 import { db } from '@/firebaseClient';
 import styles from './page.module.scss';
 
 export default function KeywordManager() {
+  const router = useRouter();
+  const allowed = useKeywordPermission();
   const [gong, setGong] = useState([]);
   const [sobang, setSobang] = useState([]);
   const [newGong, setNewGong] = useState('');
@@ -16,7 +20,11 @@ export default function KeywordManager() {
   const [drag, setDrag] = useState(null);
 
   useEffect(() => {
-    if (!db) return;
+    if (allowed === false) router.replace('/');
+  }, [allowed, router]);
+
+  useEffect(() => {
+    if (allowed !== true || !db) return;
     const unsubG = onSnapshot(doc(db, 'keywords', 'gong'), async (snap) => {
       const list = snap.data()?.list || [];
       const mapped = list.map((item) =>
@@ -45,7 +53,9 @@ export default function KeywordManager() {
       unsubG();
       unsubS();
     };
-  }, []);
+  }, [allowed]);
+
+  if (allowed !== true) return null;
 
   const update = async (group, arr) => {
     if (!db) return;

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,6 +1,8 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
+import { useAuth } from '@/context/AuthContext';
+import useKeywordPermission from '@/hooks/useKeywordPermission';
 import dynamic from 'next/dynamic';
 import styles from './page.module.scss';
 
@@ -19,8 +21,7 @@ import {
   query,
   orderBy,
 } from 'firebase/firestore';
-import { onAuthStateChanged } from 'firebase/auth';
-import { db, auth } from '@/firebaseClient';
+import { db } from '@/firebaseClient';
 
 // ====== Utils ======
 const delay = (ms) => new Promise((res) => setTimeout(res, ms));
@@ -212,7 +213,8 @@ function renderChange(curr, prev) {
 // ====== UI ======
 export default function Home() {
   // 입력/상태
-  const [user, setUser] = useState(null);
+  const { user } = useAuth();
+  const hasPermission = useKeywordPermission();
   const [date, setDate] = useState(getToday());
   const [note, setNote] = useState('');
   const [gongKeywords, setGongKeywords] = useState([]);
@@ -232,17 +234,6 @@ export default function Home() {
   const [theme, setTheme] = useState('light');
   const adminEmail = process.env.NEXT_PUBLIC_ADMIN_EMAIL;
   const isAdmin = user && user.email === adminEmail;
-
-  useEffect(() => {
-    const unsub = onAuthStateChanged(auth, (u) => {
-      if (u && u.emailVerified) {
-        setUser(u);
-      } else {
-        setUser(null);
-      }
-    });
-    return () => unsub();
-  }, []);
 
   useEffect(() => {
     const current =
@@ -579,7 +570,7 @@ export default function Home() {
       <h1 className={styles.title}>
         NS <span>(Next SEO Master)</span>
       </h1>
-      {user && (
+      {hasPermission && (
         <>
           <h2 className={styles.subTitle}>구글 검색 순위 비교(SEO)</h2>
           <p className={styles.notice}>원하는 날짜를 선택해 저장하세요.</p>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -4,11 +4,13 @@ import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/context/AuthContext';
+import useKeywordPermission from '@/hooks/useKeywordPermission';
 import styles from '@/styles/header.module.scss';
 
 export default function Header() {
   const [theme, setTheme] = useState('light');
   const { user, unverifiedEmail, logout } = useAuth();
+  const hasPermission = useKeywordPermission();
   const router = useRouter();
 
   useEffect(() => {
@@ -68,6 +70,11 @@ export default function Header() {
                 {user.displayName ? `(${user.displayName})` : ''}님 반갑습니다.
               </span>
               {user.email === adminEmail && (
+                <Link href='/admin' className={styles.managerLink}>
+                  권한 설정
+                </Link>
+              )}
+              {hasPermission && (
                 <Link href='/keywords' className={styles.managerLink}>
                   키워드 관리자
                 </Link>

--- a/src/hooks/useKeywordPermission.js
+++ b/src/hooks/useKeywordPermission.js
@@ -1,0 +1,26 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { doc, onSnapshot } from 'firebase/firestore';
+import { db } from '@/firebaseClient';
+import { useAuth } from '@/context/AuthContext';
+
+export default function useKeywordPermission() {
+  const { user } = useAuth();
+  const [allowed, setAllowed] = useState(null);
+
+  useEffect(() => {
+    if (!user) {
+      setAllowed(false);
+      return;
+    }
+    const ref = doc(db, 'permissions', 'keywordManagers');
+    const unsub = onSnapshot(ref, (snap) => {
+      const uids = snap.data()?.uids || [];
+      setAllowed(uids.includes(user.uid));
+    });
+    return () => unsub();
+  }, [user]);
+
+  return allowed;
+}


### PR DESCRIPTION
## Summary
- add Firestore-backed permission system for keyword manager access
- allow admins to grant or revoke keyword manager role via new admin page
- store users in Firestore at login/signup to populate permission list

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Next.js ESLint setup wizard prompt)

------
https://chatgpt.com/codex/tasks/task_e_68ac13c6d35c8324bb193929d10dea48